### PR TITLE
Add custom label buttons and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ const smalltalk = require('smalltalk/native');
 ```
 
 In every method of `smalltalk` last parameter *options* is optional and could be used
-to prevent handling of cancel event.
+to prevent handling of cancel event and to specify custom button label.
 
 ```js
 {
@@ -31,7 +31,7 @@ to prevent handling of cancel event.
 }
 ```
 
-## smalltalk.alert(title, message)
+## smalltalk.alert(title, message [, options])
 
 ![Alert](https://raw.githubusercontent.com/coderaiser/smalltalk/master/screen/alert.png "Alert")
 
@@ -85,6 +85,20 @@ smalltalk
     })
     .catch(() => {
         console.log('cancel');
+    });
+```
+
+## Custom label 
+
+You can use custom label passing into options param the buttons specification. For example :
+```js
+smalltalk
+    .confirm('Question', 'Are you sure?', {'buttons': {'ok':'Ok Label','cancel':'Cancel Label'}})
+    .then(() => {
+        console.log('yes');
+    })
+    .catch(() => {
+        console.log('no');
     });
 ```
 

--- a/lib/smalltalk.js
+++ b/lib/smalltalk.js
@@ -8,11 +8,15 @@ const keyDown = currify(keyDown_);
 
 const remove = bind(removeEl, '.smalltalk');
 
-const BUTTON_OK = ['OK'];
-const BUTTON_OK_CANCEL = ['OK', 'Cancel'];
+const BUTTON_OK = {'ok':'OK'};
+const BUTTON_OK_CANCEL = {'ok':'OK', 'cancel':'Cancel'};
 
-exports.alert = (title, msg) => {
-    return showDialog(title, msg, '', BUTTON_OK, {cancel: false});
+exports.alert = (title, msg, options) => {
+    const buttons = getButtons(options) || BUTTON_OK;
+    if (getButtons(options) && options.cancel != false) {
+      options.cancel = true;
+    }
+    return showDialog(title, msg, '', buttons, options);
 };
 
 exports.prompt = (title, msg, value = '', options) => {
@@ -22,13 +26,29 @@ exports.prompt = (title, msg, value = '', options) => {
         .replace(/"/g, '&quot;');
     
     const valueStr = `<input type="${ type }" value="${ val }" data-name="js-input">`;
-    
-    return showDialog(title, msg, valueStr, BUTTON_OK_CANCEL, options);
+    const buttons = getButtons(options) || BUTTON_OK_CANCEL;
+    if (getButtons(options) && options.cancel != false) {
+      options.cancel = true;
+    }
+    return showDialog(title, msg, valueStr, buttons, options);
 };
 
 exports.confirm = (title, msg, options) => {
-    return showDialog(title, msg, '', BUTTON_OK_CANCEL, options);
+    const buttons = getButtons(options) || BUTTON_OK_CANCEL;
+    if (getButtons(options) && options.cancel != false) {
+      options.cancel = true;
+    }
+    return showDialog(title, msg, '', buttons, options);
 };
+
+function getButtons(options = {}) {
+    const {buttons} = options;
+    //TODO check both buttons are specified
+    if (buttons) {
+      return buttons
+    }
+    return null;
+}
 
 function getType(options = {}) {
     const {type} = options;
@@ -48,8 +68,8 @@ function getTemplate(title, msg, value, buttons) {
         <div class="content-area">${ encodedMsg }${ value }</div>
         <div class="action-area">
             <div class="button-strip"> ${
-                buttons.map((name, i) =>
-                    `<button tabindex=${ i } data-name="js-${ name.toLowerCase() }">${ name }</button>`
+                Object.keys(buttons).map((name,i) =>
+                    `<button tabindex=${ i } data-name="js-${ name.toLowerCase() }">${ buttons[name] }</button>`
                 ).join('')
             }
             </div>
@@ -60,14 +80,14 @@ function getTemplate(title, msg, value, buttons) {
 function showDialog(title, msg, value, buttons, options) {
     const ok = store();
     const cancel = store();
-    
+
     const dialog = document.createElement('div');
     const closeButtons = [
         'cancel',
         'close',
         'ok'
     ];
-    
+
     const promise = new Promise((resolve, reject) => {
         const noCancel = options && !options.cancel;
         const empty = () => {};

--- a/test/fixture/alert-custom-label.html
+++ b/test/fixture/alert-custom-label.html
@@ -1,0 +1,9 @@
+<div class="page">
+        <div data-name="js-close" class="close-button"></div>
+        <header>title</header>
+        <div class="content-area">hello<br>world</div>
+        <div class="action-area">
+            <div class="button-strip"> <button tabindex=0 data-name="js-ok">Ok</button>
+            </div>
+        </div>
+    </div>

--- a/test/fixture/confirm-custom-label.html
+++ b/test/fixture/confirm-custom-label.html
@@ -1,0 +1,9 @@
+<div class="page">
+        <div data-name="js-close" class="close-button"></div>
+        <header>title</header>
+        <div class="content-area">message</div>
+        <div class="action-area">
+            <div class="button-strip"> <button tabindex=0 data-name="js-ok">Ok</button><button tabindex=1 data-name="js-cancel">Logout</button>
+            </div>
+        </div>
+    </div>

--- a/test/fixture/prompt-custom-label.html
+++ b/test/fixture/prompt-custom-label.html
@@ -1,0 +1,9 @@
+<div class="page">
+        <div data-name="js-close" class="close-button"></div>
+        <header>title</header>
+        <div class="content-area">message<input type="text" value="2" data-name="js-input"></div>
+        <div class="action-area">
+            <div class="button-strip"> <button tabindex=0 data-name="js-ok">Ok</button><button tabindex=1 data-name="js-cancel">Logout</button>
+            </div>
+        </div>
+    </div>

--- a/test/smalltalk.js
+++ b/test/smalltalk.js
@@ -22,7 +22,17 @@ const fixture = {
     prompt: readFixture('prompt'),
     promptPassword: readFixture('prompt.password'),
     promptNoValue: readFixture('prompt.no-value'),
+    alertCustomLabel: readFixture('alert-custom-label'),
+    confirmCustomLabel: readFixture('confirm-custom-label'),
+    promptCustomLabel: readFixture('prompt-custom-label')
 };
+
+test('Remove new line from text', (t) => {
+    before();
+    t.equal(cleanNewLine('<div class=\'test\'>\n</div>'),'<div class=\'test\'></div>', 'should be equal');
+    after();
+    t.end();
+});
 
 test('smalltalk: alert: innerHTML', (t) => {
     before();
@@ -412,6 +422,24 @@ test('smalltalk: alert: click', (t) => {
     t.end();
 });
 
+test('smalltalk: alert: custom label', (t) => {
+    before();
+    
+    const el = {
+        innerHTML: ''
+    };
+    
+    const createElement = getCreateElement(el);
+    global.document.createElement = createElement;
+    
+    var options = {'buttons' : {'ok':'Ok'}};
+    smalltalk.alert('title', 'hello\nworld', options);
+    t.equal(cleanNewLine(fixture.alertCustomLabel), cleanNewLine(el.innerHTML), 'should be equal');
+    
+    after();
+    t.end();
+});
+
 test('smalltalk: confirm: innerHTML', (t) => {
     before();
     
@@ -694,6 +722,26 @@ test('smalltalk: confirm: keydown: enter', (t) => {
     keydown(event);
 });
 
+test('smalltalk: confirm: custom label', (t) => {
+    before();
+    
+    const el = {
+        innerHTML: ''
+    };
+    
+    const createElement = getCreateElement(el);
+    global.document.createElement = createElement;
+    
+    var options = {'buttons' : {'ok':'Ok','cancel':'Logout'}};
+    smalltalk.confirm('title', 'message', options);
+
+    t.equal(cleanNewLine(fixture.confirmCustomLabel), cleanNewLine(el.innerHTML), 'should be equal');
+    
+    after();
+    t.end();
+});
+
+
 test('smalltalk: prompt: innerHTML', (t) => {
     before();
     
@@ -801,6 +849,25 @@ test('smalltalk: prompt: click on ok', (t) => {
     });
 });
 
+test('smalltalk: prompt: custom label', (t) => {
+    before();
+    
+    const el = {
+        innerHTML: ''
+    };
+    
+    const createElement = getCreateElement(el);
+    global.document.createElement = createElement;
+    
+    var options = {'buttons' : {'ok':'Ok','cancel':'Logout'}};
+    smalltalk.prompt('title', 'message', 2, options);
+    
+    t.equal(cleanNewLine(fixture.promptCustomLabel), cleanNewLine(el.innerHTML), 'should be equal');
+    
+    after();
+    t.end();
+});
+
 function getCreateElement(el = {}) {
     const querySelector = sinon.stub();
     const addEventListener = sinon.stub();
@@ -828,5 +895,9 @@ function before() {
 
 function after() {
     delete global.document;
+}
+
+function cleanNewLine(text) {
+  return text.replace(/\r?\n|\r/g,"");
 }
 


### PR DESCRIPTION
I put buttons label into `options` like `{'buttons': {'ok':'Ok Label','cancel':'Cancel Label'}}`.

I had an issue into test comparing html template : the one loaded from file system have a "newline" that I'm not able to find and remove using text editor (vi, vim, oni, atom..). My solution was add a function that remove the new line before comparing html.