### PR TITLE
Let you specify a parent element

### DIFF
--- a/lib/smalltalk.js
+++ b/lib/smalltalk.js
@@ -151,6 +151,7 @@ function showDialog(title, msg, value, buttons, options) {
     const dialog = createElement('div', {
         innerHTML,
         className: 'smalltalk',
+        parent: options.parent,
         style: `z-index: ${zIndex(zIndex() + 1)}`,
     });
     


### PR DESCRIPTION
I wanted to be able to create a dialog in a separate window which meant I had to pass in a different document.body element to be the parent element.