### PR TITLE
Support for different prompt types

### DIFF
--- a/lib/smalltalk.js
+++ b/lib/smalltalk.js
@@ -92,10 +92,11 @@ function getButtons(options = {}) {
 
 function getType(options = {}) {
     const {type} = options;
-    
-    if (type === 'password')
-        return 'password';
-    
+    const validTypes = ['date','email','number','tel','password'];
+
+    if (validTypes.includes(type))
+      return type;
+
     return 'text';
 }
 
@@ -158,6 +159,10 @@ function showDialog(title, msg, value, buttons, options) {
         el.focus();
     
     for (const el of find(dialog, ['input'])) {
+        if(el.getAttribute('type') === 'date') continue;
+        if(el.getAttribute('type') === 'email') continue;
+        if(el.getAttribute('type') === 'number') continue;
+
         el.setSelectionRange(0, value.length);
     }
     

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "eslint": "^6.1.0",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-putout": "^3.0.0",
-    "madrun": "^5.0.1",
+    "madrun": "^5.4.4",
     "nodemon": "^2.0.1",
     "nyc": "^15.0.0",
     "putasset": "^5.0.0",


### PR DESCRIPTION
Have added support for date, email, number, and tel prompts in addition to the original password prompt.

Had to make it so that setSelectionRange would only happen if it was a password, text, or url input field otherwise it errors out.

Probably better ways to do some of it, but it works for my use case on a Honeywell CT60 Android barcode scanner.